### PR TITLE
MAKE Update:  v1.12

### DIFF
--- a/MAKE.ps1
+++ b/MAKE.ps1
@@ -66,7 +66,7 @@ $PackageFilePatternExclusions = @(
 
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-$Version = "0.1.5"
+$Version = "0.1.12"
 $ModuleName = "PSServiceNow"
 $PackageName = "$ModuleName-v$($version).zip";
 

--- a/PSServiceNow.psd1
+++ b/PSServiceNow.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.5'
+ModuleVersion = '0.1.12'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'


### PR DESCRIPTION
PS Gallery's versioning was mislabeled as v1.11 instead of v1.2.  This PR aligns the numbering so both repos will be on the latest version upon pushing the development branch to master and uploading the file to PS Gallery.

