### PR TITLE
OrderBy and OrderDirection should not be mandatory

### DIFF
--- a/PSServiceNow.psm1
+++ b/PSServiceNow.psm1
@@ -10,11 +10,11 @@ function New-ServiceNowQuery{
 
     param(
         # Machine name of the field to order by
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [string]$OrderBy='opened_at',
         
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
         


### PR DESCRIPTION
I would suggest combining "Default values" (ie $OrderBy='opened_at') with the parameter as not mandatory. Alternatively use mandatory without a "Default value".