### PR TITLE
MatchExact and MatchContains now not mandatory

### DIFF
--- a/PSServiceNow.psm1
+++ b/PSServiceNow.psm1
@@ -19,11 +19,11 @@ function New-ServiceNowQuery{
         [string]$OrderDirection='Desc',
         
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [hashtable]$MatchExact,
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$true)]
+        [parameter(mandatory=$false)]
         [hashtable]$MatchContains
     )
     # Start the query off with a order direction


### PR DESCRIPTION
Is it your intention to be able to use MatchExact and MatchContains in the same query?
Maybe a better approach than what I suggest in this PR would actually be to have MatchExact and MatchContains in seperate parametersets and keep them mandatory?