### PR TITLE
Modify DateTime field processing Depending Upon DisplayValues

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -36,13 +36,13 @@ function Get-ServiceNowChangeRequest {
         [parameter(ParameterSetName='SetGlobalAuth')]
         [hashtable]$MatchContains=@{},
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
         [parameter(ParameterSetName='UseConnectionObject')]
         [parameter(ParameterSetName='SetGlobalAuth')]
         [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        [string]$DisplayValues='false',
 
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
         [ValidateNotNullOrEmpty()]

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -36,13 +36,13 @@ function Get-ServiceNowConfigurationItem {
         [parameter(ParameterSetName='SetGlobalAuth')]
         [hashtable]$MatchContains=@{},
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
         [parameter(ParameterSetName='UseConnectionObject')]
         [parameter(ParameterSetName='SetGlobalAuth')]
         [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        [string]$DisplayValues='false',
 
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
         [ValidateNotNullOrEmpty()]

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -36,13 +36,13 @@ function Get-ServiceNowIncident{
         [parameter(ParameterSetName='SetGlobalAuth')]
         [hashtable]$MatchContains=@{},
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
         [parameter(ParameterSetName='UseConnectionObject')]
         [parameter(ParameterSetName='SetGlobalAuth')]
         [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        [string]$DisplayValues='false',
 
         # Credential used to authenticate to ServiceNow  
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -1,5 +1,18 @@
 function Get-ServiceNowTable {
-    [OutputType([Array])]
+<#
+.SYNOPSIS
+    Retrieves multiple records for the specified table
+.DESCRIPTION
+    The Get-ServiceNowTable function retrieves multiple records for the specified table
+.INPUTS
+    None
+.OUTPUTS
+    System.Management.Automation.PSCustomObject
+.LINK
+    Service-Now Kingston REST Table API: https://docs.servicenow.com/bundle/kingston-application-development/page/integrate/inbound-rest/concept/c_TableAPI.html
+    Service-Now Table API FAQ: https://hi.service-now.com/kb_view.do?sysparm_article=KB0534905
+#>
+[OutputType([Array])]
     Param (
         # Name of the table we're querying (e.g. incidents)
         [parameter(Mandatory)]
@@ -21,7 +34,7 @@ function Get-ServiceNowTable {
         [parameter(ParameterSetName = 'SetGlobalAuth')]
         [int]$Limit = 10,
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
         [parameter(ParameterSetName = 'UseConnectionObject')]
         [parameter(ParameterSetName = 'SetGlobalAuth')]
@@ -59,6 +72,7 @@ function Get-ServiceNowTable {
     elseif ((Test-ServiceNowAuthIsSet)) {
         $ServiceNowCredential = $Global:ServiceNowCredentials
         $ServiceNowURL = $global:ServiceNowRESTURL
+        $ServiceNowDateFormat = $Global:ServiceNowDateFormat
     }
     else {
         throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
@@ -75,27 +89,26 @@ function Get-ServiceNowTable {
     $Result = (Invoke-RestMethod -Uri $Uri -Credential $ServiceNowCredential -Body $Body -ContentType "application/json").Result
 
     # Convert specific fields to DateTime format
+    $DefaultServiceNowDateFormat = 'yyyy-MM-dd HH:mm:ss'
     $ConvertToDateField = @('closed_at', 'expected_start', 'follow_up', 'opened_at', 'sys_created_on', 'sys_updated_on', 'work_end', 'work_start')
     ForEach ($SNResult in $Result) {
         ForEach ($Property in $ConvertToDateField) {
             If (-not [string]::IsNullOrEmpty($SNResult.$Property)) {
-                Try {
-                    # Extract the default Date/Time formatting from the local computer's "Culture" settings, and then create the format to use when parsing the date/time from Service-Now
-                    $CultureDateTimeFormat = (Get-Culture).DateTimeFormat
-                    $DateFormat = $CultureDateTimeFormat.ShortDatePattern
-                    $TimeFormat = $CultureDateTimeFormat.LongTimePattern
-                    $DateTimeFormat = "$DateFormat $TimeFormat"
-                    $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
-                }
-                Catch {
+                If ($DisplayValues -eq $True) {
+                    # DateTime fields returned in the Service-Now instance system date format need converting to the local computers "culture" setting based upon the format specified
                     Try {
-                        # Universal Format
-                        $DateTimeFormat = 'yyyy-MM-dd HH:mm:ss'
-                        $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DateTimeFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo, [System.Globalization.DateTimeStyles]::None)
+                        Write-Debug "Date Parsing field: $Property, value: $($SNResult.$Property) against global format $Global:ServiceNowDateFormat"
+                        $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $Global:ServiceNowDateFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo)
                     }
                     Catch {
-                        # If the local culture and universal formats both fail keep the property as a string (Do nothing)
+                        Throw "Problem parsing date-time field $Property with value $($SNResult.$Property) against format $Global:ServiceNowDateFormat. " +
+                              "Please verify the DateFormat parameter matches the glide.sys.date_format property of the Service-Now instance"
                     }
+                }
+                Else {
+                    # DateTime fields always returned as yyyy-MM-dd hh:mm:ss when sysparm_display_value is set to false
+                    Write-Debug "Date Parsing field: $Property, value: $($SNResult.$Property) against default format $DefaultServiceNowDateFormat"
+                    $SNResult.$Property = [DateTime]::ParseExact($($SNResult.$Property), $DefaultServiceNowDateFormat, [System.Globalization.DateTimeFormatInfo]::InvariantInfo) 
                 }
             }
         }

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -36,13 +36,13 @@ function Get-ServiceNowUser{
         [parameter(ParameterSetName='SetGlobalAuth')]
         [hashtable]$MatchContains=@{},
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
         [parameter(ParameterSetName='UseConnectionObject')]
         [parameter(ParameterSetName='SetGlobalAuth')]
         [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        [string]$DisplayValues='false',
 
         # Credential used to authenticate to ServiceNow  
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -36,13 +36,13 @@ function Get-ServiceNowUserGroup{
         [parameter(ParameterSetName='SetGlobalAuth')]
         [hashtable]$MatchContains=@{},
 
-        # Whether or not to show human readable display values instead of machine values
+        # Whether to return manipulated display values rather than actual database values.
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
         [parameter(ParameterSetName='UseConnectionObject')]
         [parameter(ParameterSetName='SetGlobalAuth')]
         [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        [string]$DisplayValues='false',
 
         # Credential used to authenticate to ServiceNow  
         [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -1,13 +1,38 @@
 function Set-ServiceNowAuth{
-    param(
+<#
+.SYNOPSIS
+    Configures default connection settings for the Service-Now Instance 
+.DESCRIPTION
+    The Set-ServiceNowAuth function configures default connection settings for the Service-Now Instance. These include the instance URL,
+    authentication credentials and date format.
+.INPUTS
+    None
+.OUTPUTS
+    System.Boolean
+.LINK
+    Service-Now Kingston Release REST API Reference: https://docs.servicenow.com/bundle/kingston-application-development/page/build/applications/concept/api-rest.html
+    Service-Now Table API FAQ: https://hi.service-now.com/kb_view.do?sysparm_article=KB0534905
+#>
+param(
+        # The URL for the ServiceNow instance being used
         [parameter(mandatory=$true)]
         [string]$url,
         
+        # Credential used to authenticate to ServiceNow
         [parameter(mandatory=$true)]
-        [System.Management.Automation.PSCredential]$Credentials
-    )
+        [System.Management.Automation.PSCredential]$Credentials,
+
+        # The date format specified in the Service-Now Instance, sys_properties table, property glide.sys.data_format. This is required
+        # to correctly convert datetime fields to the local computer locale format when the DisplayValues parameter of the Get-* functions
+        # is set to true 
+        [parameter(mandatory=$false)]
+        [String]$DateFormat=(Get-Culture).DateTimeFormat.ShortDatePattern+' '+(Get-Culture).DateTimeFormat.LongTimePattern
+        )
+
     $Global:ServiceNowURL = 'https://' + $url
     $Global:ServiceNowRESTURL = $ServiceNowURL + '/api/now/v1'
     $Global:ServiceNowCredentials = $credentials
+    $Global:ServiceNowDateFormat = $DateFormat
+    
     return $true;
 }


### PR DESCRIPTION
Rather than assuming what format DateTime fields are in as discussed here #22, I've changed the code as follows:

1. Changed the DisplayValues parameter to default to false for `Get-ServiceNowConfigurationItem`, `Get-ServiceNowIncident`, `Get-ServiceNowUser` and `Get-ServiceNowUserGroup`. This means that by default datetime fields will be returned in a fixed format, and is easily converted to the user's local culture format.
2. Added a new global variable `ServiceNowDateFormat` that can be set to match the date format configured on the ServiceNow instance. This is settable from the `Set-ServiceNowAuth` function and defaults to the user's ShortDatePattern & LongTimePattern from their local culture.
3. Modifed the `Get-ServiceNowTable` function to conditionally convert the DateTime fields based upon whether `DisplayValues` is set to true or not:
a. If true, use the `ServiceNowDateFormat` global variable as the conversion date source format
b. If false, use `yyyy-MM-dd HH:mm:ss` as the conversion date source format

I've also added some basic comment based help to the `Get-ServiceNowTable` and `Set-ServiceNowAuth` functions.

Note: if these changes are accepted, the `Readme.md` file will need updating.