### PR TITLE
Adding OAuth support, adding Cattask/variable retrieval

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowCatalogTask.ps1
+++ b/ServiceNow/Public/Get-ServiceNowCatalogTask.ps1
@@ -1,0 +1,117 @@
+﻿function Get-ServiceNowCatalogTask{
+    param(
+        # Machine name of the field to order by
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [string]$OrderBy='opened_at',
+        
+        # Direction of ordering (Desc/Asc)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [ValidateSet("Desc", "Asc")]
+        [string]$OrderDirection='Desc',
+
+        # Maximum number of records to return
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [int]$Limit=10,
+        
+        # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [hashtable]$MatchExact=@{},
+
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [hashtable]$MatchContains=@{},
+
+        # Whether or not to show human readable display values instead of machine values
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [ValidateSet("true","false", "all")]
+        [string]$DisplayValues='true',
+
+        # Credential used to authenticate to ServiceNow  
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential]
+        $ServiceNowCredential, 
+
+        # The URL for the ServiceNow instance being used  
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServiceNowURL, 
+
+        #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
+        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
+        [ValidateNotNullOrEmpty()]
+        [Hashtable]
+        $Connection,
+
+        #Optional Variable Return
+        [switch]$ReturnVariables
+
+    )
+
+    # Query Splat
+    $newServiceNowQuerySplat = @{
+        OrderBy = $OrderBy
+        OrderDirection = $OrderDirection
+        MatchExact = $MatchExact
+        MatchContains = $MatchContains
+    }
+    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+
+    # Table Splat 
+    $getServiceNowTableSplat = @{
+        Table = 'sc_task'
+        Query = $Query
+        Limit = $Limit
+        DisplayValues = $DisplayValues
+    }
+    
+    # Update the splat if the parameters have values
+    if ($null -ne $PSBoundParameters.Connection)
+    {     
+        $getServiceNowTableSplat.Add('Connection',$Connection)
+    }
+    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) 
+    {
+         $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
+         $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Perform query and return each object in the format.ps1xml format
+    $Result = Get-ServiceNowTable @getServiceNowTableSplat
+    $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.Incident")}
+    
+    #Return Variables
+    if($ReturnVariables){
+
+        #Variables linked to the parent task, query with it
+        $ParentRITM = $Result.parent.display_value
+        $Variables = Get-ServiceNowVariables -MatchContains @{request_item="$ParentRITM"}
+
+        #inject variables into Result
+        $Result.variables = $Variables
+        $Result
+    }
+    
+    else{
+        $Result
+    }
+}

--- a/ServiceNow/Public/Get-ServiceNowVariables.ps1
+++ b/ServiceNow/Public/Get-ServiceNowVariables.ps1
@@ -1,0 +1,121 @@
+﻿function Get-ServiceNowVariables{
+    param(
+        # Machine name of the field to order by
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [string]$OrderBy='opened_at',
+        
+        # Direction of ordering (Desc/Asc)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [ValidateSet("Desc", "Asc")]
+        [string]$OrderDirection='Desc',
+
+        # Maximum number of records to return
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [int]$Limit=1000,
+        
+        # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [hashtable]$MatchExact=@{},
+
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [hashtable]$MatchContains=@{},
+
+        # Whether or not to show human readable display values instead of machine values
+        [parameter(mandatory=$false)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [ValidateSet("true","false", "all")]
+        [string]$DisplayValues='true',
+
+        # Credential used to authenticate to ServiceNow  
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential]
+        $ServiceNowCredential, 
+
+        # The URL for the ServiceNow instance being used  
+        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServiceNowURL, 
+
+        #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
+        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)] 
+        [ValidateNotNullOrEmpty()]
+        [Hashtable]
+        $Connection
+    )
+
+    # Query Splat
+    $newServiceNowQuerySplat = @{
+        OrderBy = $OrderBy
+        OrderDirection = $OrderDirection
+        MatchExact = $MatchExact
+        MatchContains = $MatchContains
+    }
+    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+
+    # Table Splat 
+    $getServiceNowTableSplat = @{
+        Table = 'sc_item_option_mtom'
+        Query = $Query
+        Limit = $Limit
+        DisplayValues = $DisplayValues
+    }
+    
+    # Update the splat if the parameters have values
+    if ($null -ne $PSBoundParameters.Connection)
+    {     
+        $getServiceNowTableSplat.Add('Connection',$Connection)
+    }
+    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) 
+    {
+         $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
+         $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Perform query and return each object in the format.ps1xml format
+    $QAResult = Get-ServiceNowTable @getServiceNowTableSplat
+    $QAResult | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.Incident")}
+    $QAResult > $null
+
+    #Create QA Table, will be array of hash tables in case there are duplicates
+    $QA = @{}
+
+    #Extract Questions and Answers
+    #Inform user of how many links to fetch, for fun?
+    [int]$numberOfLinks = $QAResult.sc_item_option.link.count*2
+    Write-Host "Number of links to fetch for Variables: "$numberOfLinks -ForegroundColor Green
+
+    foreach($link in $QAResult.sc_item_option.link){
+        
+        #Must use invoke-webrequest as the api doesn't seem to work here, that means tokens DON'T work either
+         $answer = ((Invoke-WebRequest -Uri $link -ContentType "application/XML" -Credential $ServiceNowCredentials).Content | ConvertFrom-Json)
+         $answerResult = $answer.result.value
+
+        #Get Question
+         $question = ((Invoke-WebRequest -Uri $answer.Result.item_option_new.link -ContentType "application/XML" -Credential $serviceNowCredentials).Content | ConvertFrom-Json).result.question_text
+         
+        #Store hash table array in $QA
+        $QA + @{$question = $answerResult}
+    }
+
+    return $QA
+}

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -15,7 +15,7 @@ Credentials to authenticate you to the Service-Now instance provided in the Url 
 Set-ServiceNowAuth -Url tenant.service-now.com
 
 .NOTES
-The URL should be the instance name portion of the FQDN for your instance. If you browse to https://yourinstance.service-now.com the URL required for the module is yourinstance.service-now.com
+The URL should be the instance name portion of the FQDN for your instance. If you browse to https://yourinstance.service-now.com the URL required for the module is yourinstance.service-now.com. ClientID and ClientSecret are optional but nessesary if you wish to use OAuth.
 #>
 function Set-ServiceNowAuth {
     [CmdletBinding()]
@@ -36,10 +36,23 @@ function Set-ServiceNowAuth {
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.PSCredential]
-        $Credentials
+        $Credentials,
+
+        [string]$ClientID,
+
+        [string]$ClientSecret
     )
     $Global:serviceNowUrl = 'https://' + $Url
     $Global:serviceNowRestUrl = $serviceNowUrl + '/api/now/v1'
     $Global:serviceNowCredentials = $Credentials
+    $Global:Client_ID = $ClientID
+    $Global:Client_Secret = $ClientSecret
+
+
+    if ($client_id -ne $null -and $client_secret -ne $null){
+        $result = Set-ServiceNowAuthToken -ClientID $client_id -ClientSecret $client_secret
+        return $result
+    }
+
     return $true
 }

--- a/ServiceNow/Public/Set-ServiceNowAuthToken.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuthToken.ps1
@@ -1,0 +1,72 @@
+﻿<#
+.SYNOPSIS
+Requests and refreshes access token
+
+.DESCRIPTION
+Requests and refreshes access token
+
+.PARAMETER Url
+The URL of your Service-Now instance
+
+.PARAMETER Credentials
+Credentials to authenticate you to the Service-Now instance provided in the Url parameter
+
+.EXAMPLE
+Please use Set-ServiceNowAuth. It calls this function.
+
+
+#>
+
+function Set-ServiceNowAuthToken {
+
+    [cmdletBinding()]
+    param (
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        $ClientID,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        $ClientSecret,
+
+        [switch]$renewToken=$false
+
+    )
+
+    if($renewToken -eq $true){
+        try{
+            $Token = Invoke-RestMethod -Uri $serviceNowUrl/oauth_token.do -Body "grant_type=refresh_token&client_id=$clientID&client_secret=$clientSecret&refresh_token=$RefreshToken" -Method Post
+            Write-Host "Token Renew Successful" -ForegroundColor Green
+         }
+
+         catch{
+            Write-Host "There was a problem with the information supplied" -ForegroundColor Red
+            return $false
+         }
+        
+        $global:AccessToken = $Token.access_token
+        return $true
+    }
+    
+    else{
+
+        $Username = $ServiceNowCredentials.Username
+        $Password = $serviceNowCredentials.GetNetworkCredential().password
+
+        try{
+            $Token = Invoke-RestMethod -Uri $serviceNowUrl/oauth_token.do -Body "grant_type=password&client_id=$clientID&client_secret=$clientSecret&username=$Username&password=$password" -Method Post
+            Write-Host "Token Request Successful" -ForegroundColor Green
+        }
+        
+        catch{
+            Write-Host "There was a problem with the information supplied" -ForegroundColor Red
+            return $false
+        }
+        
+        $global:AccessToken = $Token.access_token
+        $global:RefreshToken = $Token.refresh_token
+        return $true
+    }
+
+}


### PR DESCRIPTION
First time pull request. Apologies if this sucks. 

Edited Set-ServiceNowAuth and Get-ServiceNowTable, created Set-ServiceNowAuthToken. These proposed changes allow OAuth to be used. Token refreshing behavior inconsistent with my account. Access token works fine. Defaults to credentials if token access fails.

Added Get-ServiceNowCatalogTask to pull Cat Tasks from Service-Now. There is an optional -ReturnVariables that uses the last changed file Get-ServiceNowVariables. This one pulls the variables associated with the Cat task down and adds them to the variable field in the $result object.

Final Notes:
- Tokens don't seem to work with the links returned to get the question/answer variables. Thus it uses a web request and the supplied credentials instead. 
- The client ID and client secret are plain text. I'm not fond of that, but anything else seemed hacky. 