### PR TITLE
Add function Get-ServiceNowTableEntry

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -94,6 +94,7 @@ function Get-ServiceNowTableEntry {
             'UseConnectionObject' {
                 $getServiceNowTableSplat.Add('Connection', $Connection)
             }
+            Default {}
         }
 
         # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -1,0 +1,117 @@
+function Get-ServiceNowTableEntry {
+    <#
+    .SYNOPSIS
+        Wraps Get-ServiceNowQuery & Get-ServiceNowTable for easier custom table queries
+    .DESCRIPTION
+        Wraps Get-ServiceNowQuery & Get-ServiceNowTable for easier custom table queries.  No formatting is provided on output.  Every property is returned by default.
+    .EXAMPLE
+        Get-ServiceNowTableEntry -Table sc_req_item -Limit 1
+
+        Returns one request item (RITM) from the sc_req_item table
+    .EXAMPLE
+        $Record = Get-ServiceNowTableEntry -Table u_customtable -MatchExact {number=$Number}
+        Update-ServiceNowTableEntry -SysID $Record.sys_id -Table u_customtable -Values {comments='Ticket updated'}
+
+        Utilize the returned object data with to provide the sys_id property required for updates and removals
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+    .NOTES
+
+    #>
+    param(
+        # Table containing the entry we're deleting
+        [parameter(mandatory=$true)]
+        [parameter(ParameterSetName='SpecifyConnectionFields')]
+        [parameter(ParameterSetName='UseConnectionObject')]
+        [parameter(ParameterSetName='SetGlobalAuth')]
+        [string]$Table,
+
+        # Machine name of the field to order by
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string]$OrderBy = 'opened_at',
+
+        # Direction of ordering (Desc/Asc)
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [ValidateSet("Desc", "Asc")]
+        [string]$OrderDirection = 'Desc',
+
+        # Maximum number of records to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [int]$Limit = 10,
+
+        # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [hashtable]$MatchExact = @{},
+
+        # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [hashtable]$MatchContains = @{},
+
+        # Whether or not to show human readable display values instead of machine values
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [ValidateSet("true", "false", "all")]
+        [string]$DisplayValues = 'true',
+
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential]
+        $ServiceNowCredential,
+
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $ServiceNowURL,
+
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
+        [ValidateNotNullOrEmpty()]
+        [Hashtable]
+        $Connection
+    )
+
+    # Query Splat
+    $newServiceNowQuerySplat = @{
+        OrderBy        = $OrderBy
+        MatchExact     = $MatchExact
+        OrderDirection = $OrderDirection
+        MatchContains  = $MatchContains
+    }
+    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+
+    # Table Splat
+    $getServiceNowTableSplat = @{
+        Table         = $Table
+        Query         = $Query
+        Limit         = $Limit
+        DisplayValues = $DisplayValues
+    }
+
+    # Update the Table Splat if the parameters have values
+    if ($null -ne $PSBoundParameters.Connection) {
+        $getServiceNowTableSplat.Add('Connection', $Connection)
+    }
+    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
+        $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
+        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties
+    Get-ServiceNowTable @getServiceNowTableSplat
+}

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -9,8 +9,8 @@ function Get-ServiceNowTableEntry {
 
         Returns one request item (RITM) from the sc_req_item table
     .EXAMPLE
-        $Record = Get-ServiceNowTableEntry -Table u_customtable -MatchExact {number=$Number}
-        Update-ServiceNowTableEntry -SysID $Record.sys_id -Table u_customtable -Values {comments='Ticket updated'}
+        $Record = Get-ServiceNowTableEntry -Table u_customtable -MatchExact @{number=$Number}
+        Update-ServiceNowTableEntry -SysID $Record.sys_id -Table u_customtable -Values @{comments='Ticket updated'}
 
         Utilize the returned object data with to provide the sys_id property required for updates and removals
     .OUTPUTS
@@ -18,100 +18,88 @@ function Get-ServiceNowTableEntry {
     .NOTES
 
     #>
+
+    [CmdletBinding(DefaultParameterSetName)]
     param(
         # Table containing the entry we're deleting
         [parameter(mandatory=$true)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
         [string]$Table,
 
         # Machine name of the field to order by
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
         [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
         [ValidateSet("true", "false", "all")]
         [string]$DisplayValues = 'true',
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [string]$ServiceNowURL,
 
         [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy        = $OrderBy
-        MatchExact     = $MatchExact
-        OrderDirection = $OrderDirection
-        MatchContains  = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+    Try {
+        # Query Splat
+        $newServiceNowQuerySplat = @{
+            OrderBy        = $OrderBy
+            MatchExact     = $MatchExact
+            OrderDirection = $OrderDirection
+            MatchContains  = $MatchContains
+            ErrorAction    = 'Stop'
+        }
+        $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = $Table
-        Query         = $Query
-        Limit         = $Limit
-        DisplayValues = $DisplayValues
-    }
+        # Table Splat
+        $getServiceNowTableSplat = @{
+            Table         = $Table
+            Query         = $Query
+            Limit         = $Limit
+            DisplayValues = $DisplayValues
+            ErrorAction   = 'Stop'
+        }
 
-    # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
+        # Update the Table Splat if an applicable parameter set name is in use
+        Switch ($PSCmdlet.ParameterSetName) {
+            'SpecifyConnectionFields' {
+                $getServiceNowTableSplat.Add('ServiceNowCredential', $Credential)
+                $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+            }
+            'UseConnectionObject' {
+                $getServiceNowTableSplat.Add('Connection', $Connection)
+            }
+        }
 
-    # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties
-    Get-ServiceNowTable @getServiceNowTableSplat
+        # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties
+        Get-ServiceNowTable @getServiceNowTableSplat
+    }
+    Catch {
+        Write-Error $PSItem
+    }
 }

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -66,7 +66,7 @@ FormatsToProcess = @('ServiceNow.format.ps1xml')
 NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowTable','Get-ServiceNowTableEntry''Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowTableEntry')
+FunctionsToExport = @('Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowTable','Get-ServiceNowTableEntry','Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowTableEntry')
 
 # List of all modules packaged with this module
 # ModuleList = @()

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -66,7 +66,7 @@ FormatsToProcess = @('ServiceNow.format.ps1xml')
 NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowTable','Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowTableEntry')
+FunctionsToExport = @('Get-ServiceNowChangeRequest','Get-ServiceNowConfigurationItem','Get-ServiceNowIncident','Get-ServiceNowRequest','Get-ServiceNowTable','Get-ServiceNowTableEntry''Get-ServiceNowUser','Get-ServiceNowUserGroup','New-ServiceNowIncident','New-ServiceNowQuery','New-ServiceNowTableEntry','Remove-ServiceNowAuth','Remove-ServiceNowTableEntry','Set-ServiceNowAuth','Test-ServiceNowAuthIsSet','Update-ServiceNowChangeRequest','Update-ServiceNowIncident','Update-ServiceNowTableEntry')
 
 # List of all modules packaged with this module
 # ModuleList = @()


### PR DESCRIPTION
Adds function Get-ServiceNowTableEntry and updates psd1 with the function to export.

While we're able to piece together Get-ServiceNowQuery and Get-ServiceNowTable to perform custom lookups the addition of Get-ServiceNowTableEntry simplifies queries in tables without an explicit function (such as Get-ServiceNowIncident).  The new function is designed just as the explicit functions but with a `Table` parameter.

I'm open to feedback on the name and validity of the addition.