### PR TITLE
v1.3.6 - Parameter Standardization

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # ServiceNow
 
-[![GitHub release](https://img.shields.io/github/release/Sam-Martin/servicenow-powershell.svg)](https://github.com/Sam-Martin/servicenow-powershell/releases/latest) [![GitHub license](https://img.shields.io/github/license/Sam-Martin/servicenow-powershell.svg)](LICENSE) ![Test Coverage](https://img.shields.io/badge/coverage-80%25-yellow.svg)
+[![GitHub release](https://img.shields.io/github/release/Sam-Martin/servicenow-powershell.svg)](https://github.com/Sam-Martin/servicenow-powershell/releases/latest) [![GitHub license](https://img.shields.io/github/license/Sam-Martin/servicenow-powershell.svg)](LICENSE) ![Test Coverage](https://img.shields.io/badge/coverage-78%25-yellow.svg)
 
 This PowerShell module provides a series of cmdlets for interacting with the [ServiceNow REST API](http://wiki.servicenow.com/index.php?title=REST_API), performed by wrapping `Invoke-RestMethod` for the API calls.
 

--- a/ServiceNow/Private/Test-ServiceNowURL.ps1
+++ b/ServiceNow/Private/Test-ServiceNowURL.ps1
@@ -1,0 +1,39 @@
+Function Test-ServiceNowURL {
+    <#
+    .SYNOPSIS
+    For use in testing ServiceNow Urls.
+
+    .DESCRIPTION
+    For use in testing ServiceNow Urls.  The test is a simple regex match in an attempt to validate that users use a 'tenant.domain.com' pattern.
+
+    .EXAMPLE
+    Test-ServiceNowURL -Url tenant.domain.com
+
+    This example can have text
+
+    .OUTPUTS
+    System.Boolean
+
+    #>
+
+    [OutputType([System.Boolean])]
+    [CmdletBinding()]
+    param (
+        # Pipeline variable
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url
+    )
+
+	begin {}
+	process	{
+        Write-Verbose "Testing url:  $Url"
+		if ($Url -match '^\w+\..*\.\w+') {
+            $true
+        }
+        else {
+            Throw "The expected URL format is tenant.domain.com"
+        }
+    }
+	end {}
+}

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -1,63 +1,46 @@
 function Get-ServiceNowChangeRequest {
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$OrderBy='opened_at',
+        [Parameter(Mandatory = $false)]
+        [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
-        [string]$OrderDirection='Desc',
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
+        [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
+        [Parameter(Mandatory = $false)]
+        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchExact=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchContains=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchContains = @{},
 
-        # Whether to return manipulated display values rather than actual database values.
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Query Splat

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -1,63 +1,46 @@
 function Get-ServiceNowConfigurationItem {
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$OrderBy='name',
+        [Parameter(Mandatory = $false)]
+        [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
-        [string]$OrderDirection='Desc',
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
+        [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
+        [Parameter(Mandatory = $false)]
+        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchExact=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchContains=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchContains = @{},
 
-        # Whether to return manipulated display values rather than actual database values.
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Query Splat

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -1,66 +1,46 @@
 function Get-ServiceNowIncident{
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$OrderBy='opened_at',
+        [Parameter(Mandatory = $false)]
+        [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
-        [string]$OrderDirection='Desc',
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
+        [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
+        [Parameter(Mandatory = $false)]
+        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchExact=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchContains=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchContains = @{},
 
-        # Whether to return manipulated display values rather than actual database values.
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
 
-        # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Query Splat

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -1,65 +1,48 @@
 function Get-ServiceNowRequest {
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
-        
+
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
-        
+
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
-        [ValidateSet("true", "false", "all")]
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential, 
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL, 
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)] 
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
-    
+
     # Query Splat
     $newServiceNowQuerySplat = @{
         OrderBy        = $OrderBy
@@ -68,7 +51,7 @@ function Get-ServiceNowRequest {
         MatchContains  = $MatchContains
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
-    
+
     # Table Splat
     $getServiceNowTableSplat = @{
         Table         = 'sc_request'
@@ -78,7 +61,7 @@ function Get-ServiceNowRequest {
     }
 
     # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {     
+    if ($null -ne $PSBoundParameters.Connection) {
         $getServiceNowTableSplat.Add('Connection', $Connection)
     }
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -44,16 +44,16 @@ function Get-ServiceNowRequestItem {
         [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection
     )

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -14,51 +14,39 @@ function Get-ServiceNowTable {
 #>
 
     [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
     Param (
         # Name of the table we're querying (e.g. incidents)
-        [parameter(Mandatory)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string]$Table,
 
         # sysparm_query param in the format of a ServiceNow encoded query string (see http://wiki.servicenow.com/index.php?title=Encoded_Query_Strings)
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [string]$Query,
 
         # Maximum number of records to return
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
 
         # Whether or not to show human readable display values instead of machine values
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
-        [ValidateSet("true", "false", "all")]
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        # Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Get credential and ServiceNow REST URL
@@ -68,6 +56,7 @@ function Get-ServiceNowTable {
         $ServiceNowURL = 'https://' + $Connection.ServiceNowUri + '/api/now/v1'
     }
     elseif ($null -ne $ServiceNowCredential -and $null -ne $ServiceNowURL) {
+        Test-ServiceNowURL -Url $ServiceNowURL
         $ServiceNowURL = 'https://' + $ServiceNowURL + '/api/now/v1'
     }
     elseif ((Test-ServiceNowAuthIsSet)) {
@@ -109,6 +98,7 @@ function Get-ServiceNowTable {
                     }
                     Catch {
                         # If the local culture and universal formats both fail keep the property as a string (Do nothing)
+                        $null = 'Silencing a PSSA alert with this line'
                     }
                 }
             }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -22,45 +22,46 @@ function Get-ServiceNowTableEntry {
     [CmdletBinding(DefaultParameterSetName)]
     param(
         # Table containing the entry we're deleting
-        [parameter(mandatory=$true)]
+        [parameter(mandatory = $true)]
         [string]$Table,
 
         # Machine name of the field to order by
-        [parameter(mandatory = $false)]
+        [parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory = $false)]
-        [ValidateSet("Desc", "Asc")]
+        [parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
         [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory = $false)]
+        [parameter(Mandatory = $false)]
         [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory = $false)]
+        [parameter(Mandatory = $false)]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory = $false)]
+        [parameter(Mandatory = $false)]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
-        [parameter(mandatory = $false)]
-        [ValidateSet("true", "false", "all")]
+        [parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
         [string]$DisplayValues = 'true',
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [Alias('ServiceNowCredential')]
         [PSCredential]$Credential,
 
-        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
-        [ValidateNotNullOrEmpty()]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
         [string]$ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection
     )

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -1,66 +1,46 @@
 function Get-ServiceNowUser{
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$OrderBy='name',
+        [Parameter(Mandatory = $false)]
+        [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
-        [string]$OrderDirection='Desc',
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
+        [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
+        [Parameter(Mandatory = $false)]
+        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchExact=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchContains=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchContains = @{},
 
-        # Whether to return manipulated display values rather than actual database values.
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
 
-        # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Query Splat

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -1,66 +1,46 @@
 function Get-ServiceNowUserGroup{
-    param(
+    [OutputType([System.Management.Automation.PSCustomObject])]
+    [CmdletBinding(DefaultParameterSetName)]
+    Param(
         # Machine name of the field to order by
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [string]$OrderBy='name',
+        [Parameter(Mandatory = $false)]
+        [string]$OrderBy = 'name',
 
         # Direction of ordering (Desc/Asc)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("Desc", "Asc")]
-        [string]$OrderDirection='Desc',
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Desc', 'Asc')]
+        [string]$OrderDirection = 'Desc',
 
         # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
+        [Parameter(Mandatory = $false)]
+        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchExact=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [hashtable]$MatchContains=@{},
+        [Parameter(Mandatory = $false)]
+        [hashtable]$MatchContains = @{},
 
-        # Whether to return manipulated display values rather than actual database values.
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [ValidateSet("true","false", "all")]
-        [string]$DisplayValues='true',
+        # Whether or not to show human readable display values instead of machine values
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('true', 'false', 'all')]
+        [string]$DisplayValues = 'true',
 
-        # Credential used to authenticate to ServiceNow
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [PSCredential]
-        $ServiceNowCredential,
+        [Alias('ServiceNowCredential')]
+        [PSCredential]$Credential,
 
-        # The URL for the ServiceNow instance being used
-        [Parameter(ParameterSetName='SpecifyConnectionFields', Mandatory=$True)]
-        [ValidateNotNullOrEmpty()]
-        [string]
-        $ServiceNowURL,
+        [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $true)]
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('Url')]
+        [string]$ServiceNowURL,
 
-        #Azure Automation Connection object containing username, password, and URL for the ServiceNow instance
-        [Parameter(ParameterSetName='UseConnectionObject', Mandatory=$True)]
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [Hashtable]
-        $Connection
+        [hashtable]$Connection
     )
 
     # Query Splat

--- a/ServiceNow/Public/Set-ServiceNowAuth.ps1
+++ b/ServiceNow/Public/Set-ServiceNowAuth.ps1
@@ -21,17 +21,9 @@ function Set-ServiceNowAuth {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [ValidateScript( {
-                if ($_ -match '^\w+\..*\.\w+') {
-                    $true
-                }
-                else {
-                    Throw "The expected URL format is tenant.domain.com"
-                }
-            })]
-        [string]
-        $Url,
+        [ValidateScript({Test-ServiceNowURL -Url $_})]
+        [Alias('ServiceNowUrl')]
+        [string]$Url,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.5'
+ModuleVersion = '1.3.6'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'
@@ -99,6 +99,8 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
+
+
 
 
 


### PR DESCRIPTION
Added a private function Test-ServiceNowUrl to perform url validation
Applied the new function to Set-ServiceNowAuth
Applied the new function to the 'lean' parameter configuration
Applied the lean parameter configuration to all the 'Get' functions.  Get-ServiceNowTable is an exception.  Validation for that function is inside the process block.  Having ValidateScript code for the parameter interrupts things when the function is called by other functions where validation already occurred.