### PR TITLE
Feature: Paging (small breaking change)

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -15,13 +15,6 @@ function Get-ServiceNowChangeRequest {
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
@@ -86,6 +79,11 @@ function Get-ServiceNowChangeRequest {
     {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -15,13 +15,6 @@ function Get-ServiceNowConfigurationItem {
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
@@ -86,6 +79,11 @@ function Get-ServiceNowConfigurationItem {
     {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -15,13 +15,6 @@ function Get-ServiceNowIncident{
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
@@ -89,6 +82,11 @@ function Get-ServiceNowIncident{
     {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -1,4 +1,5 @@
 function Get-ServiceNowRequestItem {
+    [CmdletBinding(SupportsPaging = $true)]
     param(
         # Machine name of the field to order by
         [parameter(mandatory = $false)]
@@ -14,13 +15,6 @@ function Get-ServiceNowRequestItem {
         [parameter(ParameterSetName = 'SetGlobalAuth')]
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection = 'Desc',
-
-        # Maximum number of records to return
-        [parameter(mandatory = $false)]
-        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
-        [parameter(ParameterSetName = 'UseConnectionObject')]
-        [parameter(ParameterSetName = 'SetGlobalAuth')]
-        [int]$Limit = 10,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory = $false)]
@@ -73,7 +67,6 @@ function Get-ServiceNowRequestItem {
     $getServiceNowTableSplat = @{
         Table         = 'sc_req_item'
         Query         = $Query
-        Limit         = $Limit
         DisplayValues = $DisplayValues
     }
 
@@ -84,6 +77,11 @@ function Get-ServiceNowRequestItem {
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
         $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
         $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -19,7 +19,7 @@ function Get-ServiceNowTableEntry {
 
     #>
 
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     param(
         # Table containing the entry we're deleting
         [parameter(mandatory = $true)]
@@ -77,7 +77,6 @@ function Get-ServiceNowTableEntry {
         $getServiceNowTableSplat = @{
             Table         = $Table
             Query         = $Query
-            Limit         = $Limit
             DisplayValues = $DisplayValues
             ErrorAction   = 'Stop'
         }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -34,10 +34,6 @@ function Get-ServiceNowTableEntry {
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection = 'Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory = $false)]
-        [int]$Limit = 10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory = $false)]
         [hashtable]$MatchExact = @{},
@@ -95,6 +91,11 @@ function Get-ServiceNowTableEntry {
                 $getServiceNowTableSplat.Add('Connection', $Connection)
             }
             Default {}
+        }
+
+        # Add all provided paging parameters
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+            $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
         }
 
         # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -15,13 +15,6 @@ function Get-ServiceNowUser{
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
@@ -89,6 +82,11 @@ function Get-ServiceNowUser{
     {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -15,13 +15,6 @@ function Get-ServiceNowUserGroup{
         [ValidateSet("Desc", "Asc")]
         [string]$OrderDirection='Desc',
 
-        # Maximum number of records to return
-        [parameter(mandatory=$false)]
-        [parameter(ParameterSetName='SpecifyConnectionFields')]
-        [parameter(ParameterSetName='UseConnectionObject')]
-        [parameter(ParameterSetName='SetGlobalAuth')]
-        [int]$Limit=10,
-
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]
@@ -89,6 +82,11 @@ function Get-ServiceNowUserGroup{
     {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format


### PR DESCRIPTION
Adds support for paging result sets using PowerShell's own paging parameters: `-First` and `-Skip`. 

Addresses #19.

The `-First` parameter is functionally identical to the previous `-Limit` parameter, so I have removed that parameter. I have preserved the default behavior - if `-First` is not specified, 10 results are returned. However, this will be a breaking change to scripts that provide the `-Limit` parameter. Those scripts will just need to have that parameter renamed to `-First` instead. I considered leaving `-Limit` to avoid this situation, but in my opinion, it's bad design to have redundant parameters, and since the solution is a simple rename (no need to re-think or re-design anything), I don't see it as a huge problem so long as it's documented.

The `-Skip` parameter provides the ability to start at an offset. Combining this with `-First` allows you to page through multiple result sets.

Here is a usage example:

```powershell
function Get-PagedServiceNowRequestItem {
    [CmdletBinding()]
    param(
        [Parameter(Mandatory, Position = 0)]
        [Alias('Splat')]
        [Hashtable] $ServiceNowSplat
        ,

        [Parameter()]
        [int] $PageSize = 1000
        ,

        [Parameter()]
        [int] $MaxResults
    )

    begin {
        $skip = 0
        $total = 0
        $isComplete = $false

        if ($MaxResults -and $MaxResults -lt $PageSize) {
            $PageSize = $MaxResults
        }
    }

    process {
        while (-not $isComplete) {
            $thisRecords = Get-ServiceNowRequestItem @ServiceNowSplat -First $PageSize -Skip $skip
            $thisCount = ($thisRecords | Measure-Object).Count
            $total += $thisCount
            Write-Verbose "Returned results $($skip + 1) - $total"
            $skip += $PageSize
            $thisRecords | Write-Output

            if ((-not $thisRecords) -or ($thisCount -lt $PageSize)) {
                Write-Verbose "$thisCount records were returned, compared to $PageSize expected; complete"
                $isComplete = $true
            }
            elseif ($MaxResults -and $total -ge $MaxResults) {
                Write-Verbose "-MaxResults $MaxResults was specified; complete"
                $isComplete = $true
            }
        }
    }
}

# Assume $splat contains parameters for Get-ServiceNowRequestItem (filter criteria, etc.)

# Return all results, 1000 at a time
Get-PagedServiceNowRequestItem -ServiceNowSplat $splat

# Return all results, 500 at a time
Get-PagedServiceNowRequestItem -ServiceNowSplat $splat -PageSize 500

# Return 10 results, 2 at a time
Get-PagedServiceNowRequestItem -ServiceNowSplat $splat -PageSize 2 -MaxResults 10

```

_(Edit: fixed a minor issue in the example code.)_