### PR TITLE
Fix typo in PSTypeName for Get-ServiceNowRequestItem

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -86,6 +86,6 @@ function Get-ServiceNowRequestItem {
 
     # Perform query and return each object in the format.ps1xml format
     $Result = Get-ServiceNowTable @getServiceNowTableSplat
-    $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0,'ServiceNow.Request')}
+    $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0,'ServiceNow.RequestItem')}
     $Result
 }


### PR DESCRIPTION
I made an error in the output object's type name when submitting PR #61. This change corrects that behavior, so that `Get-ServiceNowRequestItem` correctly returns an object of type `ServiceNow.RequestItem` instead of `ServiceNow.Request`. Apologies for the inconvenience.