### PR TITLE
Feature: specify fields to return

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -2,10 +2,6 @@ function Get-ServiceNowChangeRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName)]
     Param(
-        # Fields to return
-        [parameter(mandatory = $false)]
-        [string[]]$Fields,
-
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
@@ -18,6 +14,10 @@ function Get-ServiceNowChangeRequest {
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
+
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
@@ -60,7 +60,8 @@ function Get-ServiceNowChangeRequest {
     $getServiceNowTableSplat = @{
         Table           = 'change_request'
         Query           = $Query
-        Limit           = $Limit
+        Limit           = $
+        Fields          = $Fields
         DisplayValues   = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -1,5 +1,12 @@
 function Get-ServiceNowChangeRequest {
     param(
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Machine name of the field to order by
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -1,5 +1,12 @@
 function Get-ServiceNowConfigurationItem {
     param(
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Machine name of the field to order by
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -2,10 +2,6 @@ function Get-ServiceNowConfigurationItem {
     [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName)]
     Param(
-        # Fields to return
-        [parameter(mandatory = $false)]
-        [string[]]$Fields,
-
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
         [string]$OrderBy = 'name',
@@ -18,6 +14,10 @@ function Get-ServiceNowConfigurationItem {
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
+
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
@@ -61,6 +61,7 @@ function Get-ServiceNowConfigurationItem {
         Table           = 'cmdb_ci'
         Query           = $Query
         Limit           = $Limit
+        Fields          = $Fields
         DisplayValues   = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -1,5 +1,12 @@
 function Get-ServiceNowIncident{
     param(
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Machine name of the field to order by
         [parameter(mandatory=$false)]
         [parameter(ParameterSetName='SpecifyConnectionFields')]

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -2,10 +2,6 @@ function Get-ServiceNowIncident{
     [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName)]
     Param(
-        # Fields to return
-        [parameter(mandatory = $false)]
-        [string[]]$Fields,
-
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
@@ -18,6 +14,10 @@ function Get-ServiceNowIncident{
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
+
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
@@ -61,6 +61,7 @@ function Get-ServiceNowIncident{
         Table = 'incident'
         Query = $Query
         Limit = $Limit
+        Fields        = $Fields
         DisplayValues = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -2,10 +2,6 @@ function Get-ServiceNowRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName)]
     Param(
-        # Fields to return
-        [parameter(mandatory = $false)]
-        [string[]]$Fields,
-
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
@@ -18,6 +14,10 @@ function Get-ServiceNowRequest {
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
+
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
@@ -61,6 +61,7 @@ function Get-ServiceNowRequest {
         Table         = 'sc_request'
         Query         = $Query
         Limit         = $Limit
+        Fields        = $Fields
         DisplayValues = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -1,12 +1,19 @@
 function Get-ServiceNowRequest {
     param(
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Machine name of the field to order by
         [parameter(mandatory = $false)]
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
         [parameter(ParameterSetName = 'UseConnectionObject')]
         [parameter(ParameterSetName = 'SetGlobalAuth')]
         [string]$OrderBy = 'opened_at',
-        
+
         # Direction of ordering (Desc/Asc)
         [parameter(mandatory = $false)]
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
@@ -21,7 +28,7 @@ function Get-ServiceNowRequest {
         [parameter(ParameterSetName = 'UseConnectionObject')]
         [parameter(ParameterSetName = 'SetGlobalAuth')]
         [int]$Limit = 10,
-        
+
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(mandatory = $false)]
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
@@ -47,19 +54,19 @@ function Get-ServiceNowRequest {
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
         [PSCredential]
-        $ServiceNowCredential, 
+        $ServiceNowCredential,
 
         [Parameter(ParameterSetName = 'SpecifyConnectionFields', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
         [string]
-        $ServiceNowURL, 
+        $ServiceNowURL,
 
-        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)] 
+        [Parameter(ParameterSetName = 'UseConnectionObject', Mandatory = $True)]
         [ValidateNotNullOrEmpty()]
         [Hashtable]
         $Connection
     )
-    
+
     # Query Splat
     $newServiceNowQuerySplat = @{
         OrderBy        = $OrderBy
@@ -68,7 +75,7 @@ function Get-ServiceNowRequest {
         MatchContains  = $MatchContains
     }
     $Query = New-ServiceNowQuery @newServiceNowQuerySplat
-    
+
     # Table Splat
     $getServiceNowTableSplat = @{
         Table         = 'sc_request'
@@ -78,7 +85,7 @@ function Get-ServiceNowRequest {
     }
 
     # Update the Table Splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {     
+    if ($null -ne $PSBoundParameters.Connection) {
         $getServiceNowTableSplat.Add('Connection', $Connection)
     }
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -1,5 +1,12 @@
 function Get-ServiceNowRequestItem {
     param(
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Machine name of the field to order by
         [parameter(mandatory = $false)]
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
@@ -74,6 +81,7 @@ function Get-ServiceNowRequestItem {
         Table         = 'sc_req_item'
         Query         = $Query
         Limit         = $Limit
+        Fields        = $Fields
         DisplayValues = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -18,10 +18,6 @@ function Get-ServiceNowRequestItem {
     [OutputType([System.Management.Automation.PSCustomObject])]
     [CmdletBinding(DefaultParameterSetName)]
     param(
-        # Fields to return
-        [parameter(mandatory = $false)]
-        [string[]]$Fields,
-
         # Machine name of the field to order by
         [parameter(Mandatory = $false)]
         [string]$OrderBy = 'opened_at',
@@ -34,6 +30,10 @@ function Get-ServiceNowRequestItem {
         # Maximum number of records to return
         [parameter(Mandatory = $false)]
         [int]$Limit = 10,
+
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(Mandatory = $false)]

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -88,6 +88,6 @@ function Get-ServiceNowRequestItem {
 
     # Perform query and return each object in the format.ps1xml format
     $Result = Get-ServiceNowTable @getServiceNowTableSplat
-    $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0, "ServiceNow.Request")}
+    $Result | ForEach-Object {$_.PSObject.TypeNames.Insert(0, "ServiceNow.RequestItem")}
     $Result
 }

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -35,6 +35,13 @@ function Get-ServiceNowTable {
         [parameter(ParameterSetName = 'SetGlobalAuth')]
         [int]$Limit = 10,
 
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [parameter(ParameterSetName = 'SpecifyConnectionFields')]
+        [parameter(ParameterSetName = 'UseConnectionObject')]
+        [parameter(ParameterSetName = 'SetGlobalAuth')]
+        [string[]]$Fields,
+
         # Whether or not to show human readable display values instead of machine values
         [parameter(ParameterSetName = 'SpecifyConnectionFields')]
         [parameter(ParameterSetName = 'UseConnectionObject')]
@@ -82,6 +89,10 @@ function Get-ServiceNowTable {
     $Body = @{'sysparm_limit' = $Limit; 'sysparm_display_value' = $DisplayValues}
     if ($Query) {
         $Body.sysparm_query = $Query
+    }
+
+    if ($Fields) {
+        $Body.sysparm_fields = $Fields -join ','
     }
 
     # Perform table query and capture results

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -38,6 +38,10 @@ function Get-ServiceNowTableEntry {
         [parameter(Mandatory = $false)]
         [int]$Limit = 10,
 
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
+
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [parameter(Mandatory = $false)]
         [hashtable]$MatchExact = @{},
@@ -82,6 +86,7 @@ function Get-ServiceNowTableEntry {
             Table         = $Table
             Query         = $Query
             Limit         = $Limit
+            Fields        = $Fields
             DisplayValues = $DisplayValues
             ErrorAction   = 'Stop'
         }

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -15,6 +15,10 @@ function Get-ServiceNowUser{
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
 
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
+
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchExact = @{},
@@ -57,6 +61,7 @@ function Get-ServiceNowUser{
         Table = 'sys_user'
         Query = $Query
         Limit = $Limit
+        Fields = $Fields
         DisplayValues = $DisplayValues
     }
 

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -15,6 +15,10 @@ function Get-ServiceNowUserGroup{
         [Parameter(Mandatory = $false)]
         [int]$Limit = 10,
 
+        # Fields to return
+        [parameter(mandatory = $false)]
+        [string[]]$Fields,
+
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
         [Parameter(Mandatory = $false)]
         [hashtable]$MatchExact = @{},
@@ -57,6 +61,7 @@ function Get-ServiceNowUserGroup{
         Table = 'sys_user_group'
         Query = $Query
         Limit = $Limit
+        Fields = $Fields
         DisplayValues = $DisplayValues
     }
 


### PR DESCRIPTION
Adds the `-Fields` parameter, which allows the user to specify the `sysparm_fields` parameter in the ServiceNow API.

This can be used to limit the data returned for large transfers if you only care about specific fields in the API response, but it's more useful to allow [dot-walking](https://developer.servicenow.com/blog.do?p=/post/dot-walking-in-the-rest-table-api-2/) to return related information without running additional API requests.

I know I've also got #64 open right now, and there could be minor merge conflicts between the two. I'm happy to clean those up in either that PR or this one if you choose to accept both.