### PR TITLE
Feature: Add support for paging

### DIFF
--- a/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowChangeRequest.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowChangeRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -13,7 +13,7 @@ function Get-ServiceNowChangeRequest {
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowChangeRequest {
     $getServiceNowTableSplat = @{
         Table         = 'change_request'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowChangeRequest {
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowConfigurationItem.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowConfigurationItem {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -13,7 +13,7 @@ function Get-ServiceNowConfigurationItem {
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowConfigurationItem {
     $getServiceNowTableSplat = @{
         Table         = 'cmdb_ci'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowConfigurationItem {
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowIncident{
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -13,7 +13,7 @@ function Get-ServiceNowIncident{
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowIncident{
     $getServiceNowTableSplat = @{
         Table         = 'incident'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowIncident{
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
          $getServiceNowTableSplat.Add('ServiceNowCredential',$ServiceNowCredential)
          $getServiceNowTableSplat.Add('ServiceNowURL',$ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowRequest.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequest.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowRequest {
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -13,7 +13,7 @@ function Get-ServiceNowRequest {
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowRequest {
     $getServiceNowTableSplat = @{
         Table         = 'sc_request'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowRequest {
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
         $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
         $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
+++ b/ServiceNow/Public/Get-ServiceNowRequestItem.ps1
@@ -16,7 +16,7 @@ function Get-ServiceNowRequestItem {
 #>
 
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     param(
         # Machine name of the field to order by
         [parameter(Mandatory = $false)]
@@ -29,7 +29,7 @@ function Get-ServiceNowRequestItem {
 
         # Maximum number of records to return
         [parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -76,7 +76,6 @@ function Get-ServiceNowRequestItem {
     $getServiceNowTableSplat = @{
         Table         = 'sc_req_item'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -88,6 +87,16 @@ function Get-ServiceNowRequestItem {
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
         $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
         $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowTable.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTable.ps1
@@ -14,7 +14,7 @@ function Get-ServiceNowTable {
 #>
 
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param (
         # Name of the table we're querying (e.g. incidents)
         [parameter(Mandatory = $true)]
@@ -27,7 +27,7 @@ function Get-ServiceNowTable {
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -72,8 +72,48 @@ function Get-ServiceNowTable {
         throw "Exception:  You must do one of the following to authenticate: `n 1. Call the Set-ServiceNowAuth cmdlet `n 2. Pass in an Azure Automation connection object `n 3. Pass in an endpoint and credential"
     }
 
+    $Body = @{'sysparm_display_value' = $DisplayValues}
+
+    # Handle paging parameters
+    # If -Limit was provided, write a warning message, but prioritize it over -First.
+    # The value of -First defaults to [uint64]::MaxValue if not specified.
+    # If no paging information was provided, default to the legacy behavior, which was to return 10 records.
+
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        Write-Warning "The -Limit parameter is deprecated, and may be removed in a future release. Use the -First parameter instead."
+        $Body['sysparm_limit'] = $Limit
+    }
+    elseif ($PSCmdlet.PagingParameters.First -ne [uint64]::MaxValue) {
+        $Body['sysparm_limit'] = $PSCmdlet.PagingParameters.First
+    }
+    else {
+        $Body['sysparm_limit'] = 10
+    }
+
+    if ($PSCmdlet.PagingParameters.Skip) {
+        $Body['sysparm_offset'] = $PSCmdlet.PagingParameters.Skip
+    }
+
+    if ($PSCmdlet.PagingParameters.IncludeTotalCount) {
+        # Accuracy is a double between 0.0 and 1.0 representing an estimated percentage accuracy.
+        # 0.0 means we have no idea and 1.0 means the number is exact.
+
+        # ServiceNow does return this information in the X-Total-Count response header,
+        # but we're currently using Invoke-RestMethod to perform the API call, and Invoke-RestMethod
+        # does not provide the response headers, so we can't capture this info.
+
+        # To properly support this parameter, we'd need to fall back on Invoke-WebRequest, read the
+        # X-Total-Count header of the response, and update this parameter after performing the API
+        # call.
+
+        # Reference:
+        # https://developer.servicenow.com/app.do#!/rest_api_doc?v=jakarta&id=r_TableAPI-GET
+
+        [double] $accuracy = 0.0
+        $PSCmdlet.PagingParameters.NewTotalCount($PSCmdlet.PagingParameters.First, $accuracy)
+    }
+
     # Populate the query
-    $Body = @{'sysparm_limit' = $Limit; 'sysparm_display_value' = $DisplayValues}
     if ($Query) {
         $Body.sysparm_query = $Query
     }

--- a/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
+++ b/ServiceNow/Public/Get-ServiceNowTableEntry.ps1
@@ -19,7 +19,7 @@ function Get-ServiceNowTableEntry {
 
     #>
 
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     param(
         # Table containing the entry we're deleting
         [parameter(mandatory = $true)]
@@ -36,7 +36,7 @@ function Get-ServiceNowTableEntry {
 
         # Maximum number of records to return
         [parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -86,7 +86,6 @@ function Get-ServiceNowTableEntry {
         $getServiceNowTableSplat = @{
             Table         = $Table
             Query         = $Query
-            Limit         = $Limit
             Fields        = $Properties
             DisplayValues = $DisplayValues
             ErrorAction   = 'Stop'
@@ -102,6 +101,16 @@ function Get-ServiceNowTableEntry {
                 $getServiceNowTableSplat.Add('Connection', $Connection)
             }
             Default {}
+        }
+
+        # Only add the Limit parameter if it was explicitly provided
+        if ($PSBoundParameters.ContainsKey('Limit')) {
+            $getServiceNowTableSplat.Add('Limit', $Limit)
+        }
+
+        # Add all provided paging parameters
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+            $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
         }
 
         # Perform table query and return each object.  No fancy formatting here as this can pull tables with unknown default properties

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -13,7 +13,7 @@ function Get-ServiceNowUser{
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowUser{
     $getServiceNowTableSplat = @{
         Table         = 'sys_user'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowUser{
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
         $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
         $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format

--- a/ServiceNow/Public/Get-ServiceNowUser.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUser.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowUser{
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]

--- a/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
+++ b/ServiceNow/Public/Get-ServiceNowUserGroup.ps1
@@ -1,6 +1,6 @@
 function Get-ServiceNowUserGroup{
     [OutputType([System.Management.Automation.PSCustomObject])]
-    [CmdletBinding(DefaultParameterSetName)]
+    [CmdletBinding(DefaultParameterSetName, SupportsPaging)]
     Param(
         # Machine name of the field to order by
         [Parameter(Mandatory = $false)]
@@ -13,7 +13,7 @@ function Get-ServiceNowUserGroup{
 
         # Maximum number of records to return
         [Parameter(Mandatory = $false)]
-        [int]$Limit = 10,
+        [int]$Limit,
 
         # Fields to return
         [Parameter(Mandatory = $false)]
@@ -61,7 +61,6 @@ function Get-ServiceNowUserGroup{
     $getServiceNowTableSplat = @{
         Table         = 'sys_user_group'
         Query         = $Query
-        Limit         = $Limit
         Fields        = $Properties
         DisplayValues = $DisplayValues
     }
@@ -73,6 +72,16 @@ function Get-ServiceNowUserGroup{
     elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL) {
         $getServiceNowTableSplat.Add('ServiceNowCredential', $ServiceNowCredential)
         $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+    }
+
+    # Only add the Limit parameter if it was explicitly provided
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $getServiceNowTableSplat.Add('Limit', $Limit)
+    }
+
+    # Add all provided paging parameters
+    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
     }
 
     # Perform query and return each object in the format.ps1xml format


### PR DESCRIPTION
This is a cleaner re-implementation of #64. Also addresses #19.

* Add support for the `sysparm_offet` URL parameter, which was not previously supported. This is exposed via PowerShell's `Skip` parameter.
* Add support for PowerShell's `-First` parameter. This duplicates the existing functionality of the `Limit` parameter.
* Add a warning message that the `Limit` parameter is deprecated and may be removed.
* Remove default values from `Limit`, so that the above warning is only generated when the user explicitly passes the parameter.

Default behavior has not been modified - if the user does not explicitly pass either `First`, `Limit`, or `Skip`, the first 10 records are returned.

If the user passes both `First` and `Limit`, the value of the `Limit` parameter is used, and the value of the `First` parameter is discarded. This is to preserve compatibility with scripts that currently set the `Limit` parameter.

Here are a couple of usage examples:

```powershell
# Assume that $splat is a variable containing filtering information - MatchContains, MatchExact, etc.

# Get the first 10 records (identical to current behavior)
PS> Get-ServiceNowChangeRequest @splat

# Get the next 10 records after the above - new functionality
PS> Get-ServiceNowChangeRequest @splat -Skip 10

# Get the first 20 records
PS> Get-ServiceNowChangeRequest @splat -First 20

# Get the first 20 records using the Limit param - this will generate a warning message, but will work as expected
PS> Get-ServiceNowChangeRequest @splat -Limit 20

# Simple loop to get all change requests using paging
# Note - this is a very simple example, and there are a lot of ways it could be improved (like with Write-Progress)
$stillGoing = $true
$first = 10
$skip = 0
while ($stillGoing) {
    $currentResults = Get-ServiceNowChangeRequest @splat -First $first -Skip $skip
    # We've returned $first records, so add that to our $skip offset for the next run
    $skip += $first

    # If we got back fewer results than we expected, assume we're done
    # n.b. I'm sure there are better ways to detect whether we're done than this, but again, this is a simple example
    if ($currentResults.Count -lt $first) {
        Write-Verbose "Only $($currentResults.Count) results were returned when $first were expected; assuming we've hit the end"
        $stillGoing = $false
    }
    Write-Output $currentResults
}
```

Feel free to let me know if you've got any questions or would like to see any changes.