### PR TITLE
v1.5.3 - Correct New-ServiceNowIncident

### DIFF
--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -163,7 +163,7 @@ function New-ServiceNowIncident{
     {
         $newServiceNowTableEntrySplat.Add('Connection',$Connection)
     }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL)
+    elseif ($null -ne $PSBoundParameters.ServiceNowCredential -and $null -ne $PSBoundParameters.ServiceNowURL)
     {
         $newServiceNowTableEntrySplat.Add('ServiceNowCredential',$ServiceNowCredential)
         $newServiceNowTableEntrySplat.Add('ServiceNowURL',$ServiceNowURL)

--- a/ServiceNow/ServiceNow.psd1
+++ b/ServiceNow/ServiceNow.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ServiceNow.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.5.2'
+ModuleVersion = '1.5.3'
 
 # ID used to uniquely identify this module
 GUID = 'b90d67da-f8d0-4406-ad74-89d169cd0633'
@@ -99,6 +99,8 @@ PrivateData = @{
 # DefaultCommandPrefix = ''
 
 }
+
+
 
 
 


### PR DESCRIPTION
I let a bulk find/replace go by with New-ServiceNowIncident that shouldn't have been included.  