### PR TITLE
Added Pipeline support to Get-ServiceNowIncident

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,9 +65,28 @@ Get-ServiceNowIncident -MatchContains @{short_description='PowerShell'}
 ```PowerShell
 Import-Module ServiceNow
 Get-ServiceNowIncident -MatchContains @{short_description='PowerShell'} -ServiceNowCredential $PSCredential -ServiceNowURL $ServiceNowURL
+
+```
+
+### Example - Retrieving an Incident Containing the Word 'PowerShell' and 'Admin'
+
+```PowerShell
+Import-Module ServiceNow
+@(
+        [pscustomobject]@{MatchContains=@{short_description='PowerShell'}},
+        [pscustomobject]@{MatchContains=@{short_description='Admin'}}
+)| Get-ServiceNowIncident
+
 ```
 
 ### Example - Update a Ticket
+
+```PowerShell
+$Incident = Get-ServiceNowIncident -Limit 1 -MatchContains @{short_description='PowerShell'}
+Update-ServiceNowIncident -SysID $Incident.Sys_ID -Values @{comments='Updated via PowerShell'}
+```
+
+### Example - Update many tickets
 
 ```PowerShell
 $Incident = Get-ServiceNowIncident -Limit 1 -MatchContains @{short_description='PowerShell'}

--- a/ServiceNow/Public/Get-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/Get-ServiceNowIncident.ps1
@@ -21,11 +21,17 @@ function Get-ServiceNowIncident{
         [string[]]$Properties,
 
         # Hashtable containing machine field names and values returned must match exactly (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName
+        )]
         [hashtable]$MatchExact = @{},
 
         # Hashtable containing machine field names and values returned rows must contain (will be combined with AND)
-        [Parameter(Mandatory = $false)]
+        [Parameter(
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName
+        )]
         [hashtable]$MatchContains = @{},
 
         # Whether or not to show human readable display values instead of machine values
@@ -47,47 +53,48 @@ function Get-ServiceNowIncident{
         [ValidateNotNullOrEmpty()]
         [hashtable]$Connection
     )
+    process{
+        # Query Splat
+        $newServiceNowQuerySplat = @{
+            OrderBy = $OrderBy
+            OrderDirection = $OrderDirection
+            MatchExact = $MatchExact
+            MatchContains = $MatchContains
+        }
+        $Query = New-ServiceNowQuery @newServiceNowQuerySplat
 
-    # Query Splat
-    $newServiceNowQuerySplat = @{
-        OrderBy = $OrderBy
-        OrderDirection = $OrderDirection
-        MatchExact = $MatchExact
-        MatchContains = $MatchContains
-    }
-    $Query = New-ServiceNowQuery @newServiceNowQuerySplat
+        # Table Splat
+        $getServiceNowTableSplat = @{
+            Table         = 'incident'
+            Query         = $Query
+            Fields        = $Properties
+            DisplayValues = $DisplayValues
+        }
 
-    # Table Splat
-    $getServiceNowTableSplat = @{
-        Table         = 'incident'
-        Query         = $Query
-        Fields        = $Properties
-        DisplayValues = $DisplayValues
-    }
+        # Update the splat if the parameters have values
+        if ($null -ne $PSBoundParameters.Connection) {
+            $getServiceNowTableSplat.Add('Connection', $Connection)
+        }
+        elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
+            $getServiceNowTableSplat.Add('Credential', $Credential)
+            $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
+        }
 
-    # Update the splat if the parameters have values
-    if ($null -ne $PSBoundParameters.Connection) {
-        $getServiceNowTableSplat.Add('Connection', $Connection)
-    }
-    elseif ($null -ne $PSBoundParameters.Credential -and $null -ne $PSBoundParameters.ServiceNowURL) {
-        $getServiceNowTableSplat.Add('Credential', $Credential)
-        $getServiceNowTableSplat.Add('ServiceNowURL', $ServiceNowURL)
-    }
+        # Only add the Limit parameter if it was explicitly provided
+        if ($PSBoundParameters.ContainsKey('Limit')) {
+            $getServiceNowTableSplat.Add('Limit', $Limit)
+        }
 
-    # Only add the Limit parameter if it was explicitly provided
-    if ($PSBoundParameters.ContainsKey('Limit')) {
-        $getServiceNowTableSplat.Add('Limit', $Limit)
-    }
+        # Add all provided paging parameters
+        ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
+            $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
+        }
 
-    # Add all provided paging parameters
-    ($PSCmdlet.PagingParameters | Get-Member -MemberType Property).Name | Foreach-Object {
-        $getServiceNowTableSplat.Add($_, $PSCmdlet.PagingParameters.$_)
+        # Perform query and return each object in the format.ps1xml format
+        $Result = Get-ServiceNowTable @getServiceNowTableSplat
+        If (-not $Properties) {
+            $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.Incident")}
+        }
+        $Result
     }
-
-    # Perform query and return each object in the format.ps1xml format
-    $Result = Get-ServiceNowTable @getServiceNowTableSplat
-    If (-not $Properties) {
-        $Result | ForEach-Object{$_.PSObject.TypeNames.Insert(0,"ServiceNow.Incident")}
-    }
-    $Result
 }


### PR DESCRIPTION
Added pipeline support to the Get-ServiceNowIncident command to allow some different use cases. Also added an example to the readme.

I was thinking about going through a few more commands and updating them for pipeline support as well if you think its usefull.

Thinking something like the following

```powershell
# Update incidents with admin and powershell and save to variable
$UpdatedIncidents = @(
        "Admin","Powershell"
    ) | 
    ForEach-Object{ [pscustomobject]@{MatchContains=@{short_description=$_}}} | 
    Get-ServiceNowIncident -Verbose | 
    ForEach-Object {
        [pscustomobject]@{ 
            SysID= $_.Sys_ID
            Values= @{comments='Updated via PowerShell'}
        }
    } | Update-ServiceNowIncident
```