### PR TITLE
Add breaks to Switch Statments

### DIFF
--- a/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
+++ b/ServiceNow/Public/New-ServiceNowChangeRequest.ps1
@@ -129,14 +129,14 @@ function New-ServiceNowChangeRequest {
                 If ($null -ne $PSBoundParameters.$Parameter) {
                     # Turn the defined parameter name into the ServiceNow attribute name
                     $KeyToAdd = Switch ($Parameter) {
-                        AssignmentGroup { 'assignment_group' }
-                        Caller { 'caller_id' }
-                        Category { 'category' }
-                        Comment { 'comments' }
-                        ConfigurationItem { 'cmdb_ci' }
-                        Description { 'description' }
-                        ShortDescription { 'short_description' }
-                        Subcategory { 'subcategory' }
+                        AssignmentGroup { 'assignment_group'; break}
+                        Caller { 'caller_id'; break}
+                        Category { 'category'; break}
+                        Comment { 'comments'; break}
+                        ConfigurationItem { 'cmdb_ci'; break}
+                        Description { 'description'; break}
+                        ShortDescription { 'short_description'; break}
+                        Subcategory { 'subcategory'; break}
                     }
                     $TableEntryValues.Add($KeyToAdd, $PSBoundParameters.$Parameter)
                 }

--- a/ServiceNow/Public/New-ServiceNowIncident.ps1
+++ b/ServiceNow/Public/New-ServiceNowIncident.ps1
@@ -119,14 +119,14 @@ function New-ServiceNowIncident{
         If ($null -ne $PSBoundParameters.$Parameter) {
             # Turn the defined parameter name into the ServiceNow attribute name
             $KeyToAdd = Switch ($Parameter) {
-                AssignmentGroup     {'assignment_group'}
-                Caller              {'caller_id'}
-                Category            {'category'}
-                Comment             {'comments'}
-                ConfigurationItem   {'cmdb_ci'}
-                Description         {'description'}
-                ShortDescription    {'short_description'}
-                Subcategory         {'subcategory'}
+                AssignmentGroup     {'assignment_group'; break}
+                Caller              {'caller_id'; break}
+                Category            {'category'; break}
+                Comment             {'comments'; break}
+                ConfigurationItem   {'cmdb_ci'; break}
+                Description         {'description'; break}
+                ShortDescription    {'short_description'; break}
+                Subcategory         {'subcategory'; break}
             }
             $TableEntryValues.Add($KeyToAdd,$PSBoundParameters.$Parameter)
         }

--- a/ServiceNow/Public/New-ServiceNowQuery.ps1
+++ b/ServiceNow/Public/New-ServiceNowQuery.ps1
@@ -49,7 +49,7 @@ function New-ServiceNowQuery {
 
         # Start the query off with a order direction
         $Order = Switch ($OrderDirection) {
-            'Asc'   {'ORDERBY'}
+            'Asc'   {'ORDERBY'; break}
             Default {'ORDERBYDESC'}
         }
         [void]$Query.Append($Order)


### PR DESCRIPTION
Adding the breaks to the switch statements speeds up the processing of the bound parameters. 